### PR TITLE
[Resolves #11] Navigating to the short url redirects to full url

### DIFF
--- a/app/concepts/v1/url/operation/visit.rb
+++ b/app/concepts/v1/url/operation/visit.rb
@@ -1,0 +1,22 @@
+require 'trailblazer'
+
+module V1
+  module Url
+    # NOTE: Visit Operation provides the logic for handling
+    # the visiting of a specific shortned url. Besides finding the model
+    # it will be responsible for the data tracking
+    class Visit < Trailblazer::Operation
+      step :setup_model!
+      failure :model_not_found!
+
+      def setup_model!(options, params:, **)
+        options['model'] = ::Url.find_by(short_code: params['short_code'])
+        !options['model'].nil?
+      end
+
+      def model_not_found!(options, **)
+        options['result.model'] = 'Url short code not found'
+      end
+    end
+  end
+end

--- a/app/controllers/v1/urls_controller.rb
+++ b/app/controllers/v1/urls_controller.rb
@@ -10,5 +10,9 @@ module V1
         }, status: :unprocessable_entity
       end
     end
+
+    def show
+      render nothing: true
+    end
   end
 end

--- a/app/controllers/v1/urls_controller.rb
+++ b/app/controllers/v1/urls_controller.rb
@@ -12,7 +12,12 @@ module V1
     end
 
     def show
-      render nothing: true
+      result = ::V1::Url::Visit.(params)
+      if result.success?
+        redirect_to result['model'].full_url
+      else
+        render file: 'public/404.html', status: :not_found, layout: false
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  get '/:short_code', to: 'v1/urls#show'
   namespace :v1 do
     resources :urls, only: [:create]
   end

--- a/spec/requests/v1/urls_management_spec.rb
+++ b/spec/requests/v1/urls_management_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'URLs Creation', type: :request do
+RSpec.describe 'URLs Management', type: :request do
   describe 'post create' do
     let(:request) { post '/v1/urls', params: params }
 
@@ -27,6 +27,26 @@ RSpec.describe 'URLs Creation', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
         expected_body = { errors: ["Full url can't be blank"] }.to_json
         expect(response.body).to eq expected_body
+      end
+    end
+  end
+
+  describe 'get show' do
+    let(:params) { { url: { full_url: 'http://google.com' } } }
+    let(:existing_url) { ::V1::Url::Create.(params)['model'] }
+    let(:request) { get "/#{short_code}" }
+
+    before do
+      request
+    end
+
+    describe 'when its a valid short url' do
+      let(:short_code) { existing_url.short_code }
+
+      it 'redirects to the full url' do
+        expect(response).to have_http_status(:redirect)
+        follow_redirect!
+        expect(response).to have_http_status(:success)
       end
     end
   end

--- a/spec/requests/v1/urls_management_spec.rb
+++ b/spec/requests/v1/urls_management_spec.rb
@@ -49,5 +49,13 @@ RSpec.describe 'URLs Management', type: :request do
         expect(response).to have_http_status(:success)
       end
     end
+
+    describe 'when its a valid short url' do
+      let(:short_code) { 'bananas' }
+
+      it 'redirects to the full url' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end


### PR DESCRIPTION
# Feature Title

 Navigating to the short url redirects to full url

# Changes made

- Added route for short urls
- Opened API endpoint for visiting the short url
- Added operation for handling the visiting logic
- Renamed request specs as it made more sense to keep them both in one place

# How does the solution address the issue

The route accepts any get requests with a param after the root and flows to the url controller.
The controller calls the visit operation that for now simply looks for the record and if any, then controller redirects to the full url.