### PR TITLE
[Resolves #4] Open api endpoint to display statistics on url

### DIFF
--- a/app/concepts/v1/url/operation/fetch_statistics.rb
+++ b/app/concepts/v1/url/operation/fetch_statistics.rb
@@ -1,0 +1,14 @@
+require 'trailblazer'
+
+module V1
+  module Url
+    class FetchStatistics < Trailblazer::Operation
+      step :setup_model!
+
+      def setup_model!(options, params:, **)
+        options['model'] = ::Url.find_by(short_code: params['short_code'])
+        !options['model'].nil?
+      end
+    end
+  end
+end

--- a/app/concepts/v1/url/operation/fetch_statistics.rb
+++ b/app/concepts/v1/url/operation/fetch_statistics.rb
@@ -4,6 +4,11 @@ module V1
   module Url
     class FetchStatistics < Trailblazer::Operation
       step :setup_model!
+      failure :model_not_found!
+
+      def model_not_found!(options, **)
+        options['result.model'] = 'Url short code not found'
+      end
 
       def setup_model!(options, params:, **)
         options['model'] = ::Url.find_by(short_code: params['short_code'])

--- a/app/concepts/v1/url/representer.rb
+++ b/app/concepts/v1/url/representer.rb
@@ -11,6 +11,18 @@ module V1
           URI.join(root_url, represented.short_code).to_s
         end
       end
+
+      class Statistics < Representable::Decorator
+        include Representable::JSON
+
+        property :short_code
+        property :access_count, exec_context: :decorator
+        collection :url_statistics, decorator: V1::UrlStatistic::Representer::Full
+
+        def access_count
+          represented.url_statistics.count
+        end
+      end
     end
   end
 end

--- a/app/concepts/v1/url_statistic/representer.rb
+++ b/app/concepts/v1/url_statistic/representer.rb
@@ -1,0 +1,14 @@
+module V1
+  module UrlStatistic
+    module Representer
+      class Full < Representable::Decorator
+        include Representable::JSON
+        property :user
+        property :user_agent
+        property :accept_language
+        property :remote_addr
+        property :host
+      end
+    end
+  end
+end

--- a/app/controllers/v1/stats_controller.rb
+++ b/app/controllers/v1/stats_controller.rb
@@ -1,0 +1,10 @@
+module V1
+  class StatsController < ApplicationController
+    def show
+      # TODO: Operation to fetch statistics
+      # TODO: Representer for statistics
+      # TODO: Render json
+      render json: {}, status: :ok
+    end
+  end
+end

--- a/app/controllers/v1/stats_controller.rb
+++ b/app/controllers/v1/stats_controller.rb
@@ -1,10 +1,12 @@
 module V1
   class StatsController < ApplicationController
     def show
-      # TODO: Operation to fetch statistics
-      # TODO: Representer for statistics
-      # TODO: Render json
-      render json: {}, status: :ok
+      result = ::V1::Url::FetchStatistics.(params)
+      if result.success?
+        render json: ::V1::Url::Representer::Statistics.new(result['model']), status: :ok
+      else
+        render json: { errors: result['model'] }, status: :unprocessable_entity
+      end
     end
   end
 end

--- a/app/controllers/v1/stats_controller.rb
+++ b/app/controllers/v1/stats_controller.rb
@@ -7,7 +7,7 @@ module V1
                status: :ok
       else
         render json: { errors: result['result.model'] },
-               status: :unprocessable_entity
+               status: :not_found
       end
     end
   end

--- a/app/controllers/v1/stats_controller.rb
+++ b/app/controllers/v1/stats_controller.rb
@@ -3,9 +3,11 @@ module V1
     def show
       result = ::V1::Url::FetchStatistics.(params)
       if result.success?
-        render json: ::V1::Url::Representer::Statistics.new(result['model']), status: :ok
+        render json: ::V1::Url::Representer::Statistics.new(result['model']),
+               status: :ok
       else
-        render json: { errors: result['model'] }, status: :unprocessable_entity
+        render json: { errors: result['result.model'] },
+               status: :unprocessable_entity
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get '/:short_code', to: 'v1/urls#show'
   namespace :v1 do
     resources :urls, only: [:create]
+    resources :stats, only: [:show]
   end
 
   root to: 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get '/:short_code', to: 'v1/urls#show'
   namespace :v1 do
     resources :urls, only: [:create]
-    resources :stats, only: [:show]
+    resources :stats, only: [:show], param: :short_code
   end
 
   root to: 'home#index'

--- a/spec/requests/v1/urls_management_spec.rb
+++ b/spec/requests/v1/urls_management_spec.rb
@@ -74,8 +74,9 @@ RSpec.describe 'URLs Management', type: :request do
       let(:short_code) { 'bananas' }
 
       it 'returns a json with all the statistics for the url' do
-        expect(response).to have_http_status(:unprocessable_entity)
-        expect(JSON.parse(response.body)['errors']).to eq 'Url short code not found'
+        expect(response).to have_http_status(:not_found)
+        errors = JSON.parse(response.body)['errors']
+        expect(errors).to eq 'Url short code not found'
       end
     end
   end

--- a/spec/requests/v1/urls_management_spec.rb
+++ b/spec/requests/v1/urls_management_spec.rb
@@ -69,5 +69,14 @@ RSpec.describe 'URLs Management', type: :request do
         expect(response.body).to eq expected_body
       end
     end
+
+    describe 'when its an ivalid url' do
+      let(:short_code) { 'bananas' }
+
+      it 'returns a json with all the statistics for the url' do
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['errors']).to eq 'Url short code not found'
+      end
+    end
   end
 end


### PR DESCRIPTION
# Feature Title

Open api endpoint to display statistics on url

# Changes made

- Added route for fetching statistics specific to a url short code
- Created operation for fetching the requested url
- Added Statistics representer

# How does the solution address the issue

This simple API endpoint allows any user to request for the current statistics existing on a specific url short code.
Currently returns the access count and the details of each one of the accesses made.